### PR TITLE
Improve HttpError Body Recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,7 @@ every {
     options {
         providerStates = listOf("The request should return a 400 Bad request")
     }
-    throw HttpClientErrorException.create(
-        HttpStatus.BAD_REQUEST,
-        "The title contains unexpected character",
-        HttpHeaders.EMPTY,
-        null,
-        null
-    )
+    anError(ResponseEntity.badRequest().body("The title contains unexpected character"))
 }
 ```
 

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/API.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/API.kt
@@ -23,8 +23,7 @@ infix fun <T, B> MockKStubScope<T, B>.willRespondWith(answer: PactMockKAnswerSco
     return answers {
         val pactScope = PactMockKAnswerScope<T, B>(this)
         val result = runCatching { answer.invoke(pactScope, it) }
-        PactMockk.intercept(it, result, pactScope.pactOptions)
-        result.getOrThrow()
+        PactMockk.interceptAndGet(it, result, pactScope.pactOptions)
     }
 }
 

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockKAnswerScope.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockKAnswerScope.kt
@@ -6,6 +6,8 @@ class PactMockKAnswerScope<T, B>(mockKAnswerScope: MockKAnswerScope<T, B>) {
 
     internal val pactOptions = InteractionOptions()
 
+    internal var errorResponse: Any? = null
+
     fun options(block: InteractionOptions.() -> Unit) = pactOptions.apply(block)
 
     val invocation = mockKAnswerScope.invocation
@@ -30,5 +32,7 @@ class PactMockKAnswerScope<T, B>(mockKAnswerScope: MockKAnswerScope<T, B>) {
     inline fun <reified T> arg(n: Int) = invocation.args[n] as T
 
     val scope = mockKAnswerScope
+
+    fun <E : Any> anError(response: E): Nothing = throw PactMockResponseError(response)
 
 }

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockResponseError.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockResponseError.kt
@@ -1,0 +1,4 @@
+package io.github.ludorival.pactjvm.mockk
+
+class PactMockResponseError(val response: Any)
+        : RuntimeException("This interaction returns an error $response")

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockk.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockk.kt
@@ -46,12 +46,13 @@ internal object PactMockk {
         )
     }
 
-    internal fun <T> intercept(call: Call, response: Result<T>, interactionOptions: InteractionOptions) {
+    internal fun <T> interceptAndGet(call: Call, response: Result<T>, interactionOptions: InteractionOptions): T {
         val adapter = getAdapterFor(call)
-        if (adapter != null) {
+        return if (adapter != null) {
             val interaction = adapter.buildInteraction(call, response, interactionOptions)
             addInteraction(interaction)
-        }
+            adapter.returnsResult(response)
+        } else response.getOrThrow()
     }
 
     private fun serializeRequestAndResponse(

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockkAdapter.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockkAdapter.kt
@@ -40,4 +40,5 @@ abstract class PactMockkAdapter {
     abstract fun <T> Result<T>.getResponse(): Pact.Interaction.Response
 
 
+    open fun <T> returnsResult(result: Result<T>) = result.getOrThrow()
 }

--- a/pact-jvm-mockk-spring/src/test/kotlin/io/github/ludorival/pactjvm/mockk/spring/contracts/ShoppingServiceContracts.kt
+++ b/pact-jvm-mockk-spring/src/test/kotlin/io/github/ludorival/pactjvm/mockk/spring/contracts/ShoppingServiceContracts.kt
@@ -45,13 +45,7 @@ fun RestTemplate.willReturnAnErrorWhenCreateShoppingList() = every {
         description = "should return a 400 Bad request"
         providerStates = listOf("The request should return a 400 Bad request")
     }
-    throw HttpClientErrorException.create(
-        HttpStatus.BAD_REQUEST,
-        "The title contains unexpected character",
-        HttpHeaders.EMPTY,
-        null,
-        null
-    )
+    anError(ResponseEntity.badRequest().body("The title contains unexpected character"))
 }
 
 fun RestTemplate.willGetShoppingList() = every {


### PR DESCRIPTION

**Description:**
This pull request enhances the error handling mechanism in the `pact-jvm-mockk` plugin by improving the way HttpError responses are recorded. Key changes include:

1. **Addition of `anError` Function:**
   - Introduced a new helper function `anError` to throw a `PactMockResponseError` with a detailed response body.
   - This replaces the direct usage of `HttpClientErrorException`.

2. **Refactoring Interception Logic:**
   - Refactored the interception logic by introducing `interceptAndGet` to ensure proper handling and returning of results or errors.
   - Simplifies the existing `intercept` method by delegating result handling to adapters.

3. **Enhancement in Adapter:**
   - Enhanced `SpringRestTemplateMockkAdapter` to handle `PactMockResponseError` and construct `HttpClientErrorException` with detailed error information.
   - Supports both the original and detailed error handling seamlessly.

4. **Internal Changes:**
   - Introduced `errorResponse` in `PactMockKAnswerScope` to capture error responses.
   - Added `PactMockResponseError` class to encapsulate error responses.

These changes aim to improve the expressiveness and clarity of HTTP error responses recorded during Pacts.

**Type of Change:**
- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Non-Breaking Change
- [ ] Documentation Update

**Checklist:**
- [x] Updated related documentation.
- [x] Refactored code to improve readability.
- [x] Added/updated unit tests to ensure the correctness of changes.
- [x] Ran the test suite and confirmed all tests are passing.

---

Please review the changes and provide feedback. Thank you!