### PR TITLE
Change the interaction DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Run your tests, and you should see the generated pact files in your `src/test/re
 
 ### Set a description
 
-By default, the description is the test method name. You can set a description for each interaction.
+By default, the description is building from the request details. You can set a description for each interaction.
 
 Use `willRespondWith` like
 
@@ -164,9 +164,7 @@ Use `willRespondWith` like
 every {
     restTemplate.getForEntity(match<String> { it.contains("user-service") }, UserProfile::class.java)
 } willRespondWith {
-    options {
-        description = "get the user profile"
-    }
+    description("get the user profile")
     ResponseEntity.ok(
         USER_PROFILE
     )
@@ -186,10 +184,8 @@ To specify the provider states :
 every {
     restTemplate.getForEntity(match<String> { it.contains("user-service") }, UserProfile::class.java)
 } willRespondWith {
-    options {
-        description = "get the user profile"
-        providerStates = listOf("The user has a preferred shopping list")
-    }
+    description("get the user profile")
+    providerState("The user has a preferred shopping list")
     ResponseEntity.ok(
         USER_PROFILE
     )
@@ -209,9 +205,7 @@ every {
         eq(ShoppingList::class.java)
     )
 } willRespondWith {
-    options {
-        providerStates = listOf("The request should return a 400 Bad request")
-    }
+    providerState("The request should return a 400 Bad request")
     anError(ResponseEntity.badRequest().body("The title contains unexpected character"))
 }
 ```

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/API.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/API.kt
@@ -23,7 +23,7 @@ infix fun <T, B> MockKStubScope<T, B>.willRespondWith(answer: PactMockKAnswerSco
     return answers {
         val pactScope = PactMockKAnswerScope<T, B>(this)
         val result = runCatching { answer.invoke(pactScope, it) }
-        PactMockk.interceptAndGet(it, result, pactScope.pactOptions)
+        PactMockk.interceptAndGet(it, result, pactScope)
     }
 }
 

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/InteractionBuilder.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/InteractionBuilder.kt
@@ -1,0 +1,10 @@
+package io.github.ludorival.pactjvm.mockk
+
+interface InteractionBuilder {
+    fun description(description: String): InteractionBuilder
+
+    fun providerState(providerState: String, params: Map<String, Any?> ? = null): InteractionBuilder
+
+
+    fun build(request: Pact.Interaction.Request, response: Pact.Interaction.Response): Pact.Interaction
+}

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/InteractionBuilderImpl.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/InteractionBuilderImpl.kt
@@ -1,0 +1,23 @@
+package io.github.ludorival.pactjvm.mockk
+
+class InteractionBuilderImpl : InteractionBuilder {
+
+    private var description: String? = null
+    private val providerStates: MutableList<Pact.Interaction.ProviderState> = mutableListOf()
+    override fun description(description: String): InteractionBuilder = apply { this.description = description }
+
+    override fun providerState(providerState: String, params: Map<String, Any?>?): InteractionBuilder = apply {
+        providerStates.add(Pact.Interaction.ProviderState(providerState, params))
+    }
+
+    override fun build(request: Pact.Interaction.Request, response: Pact.Interaction.Response): Pact.Interaction {
+        return Pact.Interaction(
+            description = description
+                ?: "${request.method} ${request.path}?${request.query ?: ""} returns ${response.status}",
+            providerStates = providerStates.ifEmpty { null },
+            request = request,
+            response = response
+        )
+    }
+
+}

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/InteractionOptions.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/InteractionOptions.kt
@@ -1,6 +1,0 @@
-package io.github.ludorival.pactjvm.mockk
-
-data class InteractionOptions(
-    var description: String? = null,
-    var providerStates: List<String>? = null
-)

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/Pact.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/Pact.kt
@@ -27,7 +27,7 @@ data class Pact(
         val response: Response
     ) {
 
-        data class ProviderState(val name: String)
+        data class ProviderState(val name: String, val params: Map<String, Any?>? = null)
         data class Request(
             val method: Method,
             val path: String,

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockKAnswerScope.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockKAnswerScope.kt
@@ -2,13 +2,7 @@ package io.github.ludorival.pactjvm.mockk
 
 import io.mockk.MockKAnswerScope
 
-class PactMockKAnswerScope<T, B>(mockKAnswerScope: MockKAnswerScope<T, B>) {
-
-    internal val pactOptions = InteractionOptions()
-
-    internal var errorResponse: Any? = null
-
-    fun options(block: InteractionOptions.() -> Unit) = pactOptions.apply(block)
+class PactMockKAnswerScope<T, B>(mockKAnswerScope: MockKAnswerScope<T, B>): InteractionBuilder by InteractionBuilderImpl() {
 
     val invocation = mockKAnswerScope.invocation
     val matcher = mockKAnswerScope.matcher

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockk.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockk.kt
@@ -46,10 +46,10 @@ internal object PactMockk {
         )
     }
 
-    internal fun <T> interceptAndGet(call: Call, response: Result<T>, interactionOptions: InteractionOptions): T {
+    internal fun <T> interceptAndGet(call: Call, response: Result<T>, interactionBuilder: InteractionBuilder): T {
         val adapter = getAdapterFor(call)
         return if (adapter != null) {
-            val interaction = adapter.buildInteraction(call, response, interactionOptions)
+            val interaction = adapter.buildInteraction(call, response, interactionBuilder)
             addInteraction(interaction)
             adapter.returnsResult(response)
         } else response.getOrThrow()

--- a/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockkAdapter.kt
+++ b/pact-jvm-mockk-core/src/main/kotlin/io/github/ludorival/pactjvm/mockk/PactMockkAdapter.kt
@@ -10,22 +10,18 @@ abstract class PactMockkAdapter {
     open fun <T> buildInteraction(
         call: Call,
         result: Result<T>,
-        interactionOptions: InteractionOptions
+        interactionBuilder: InteractionBuilder
     ): Pact.Interaction {
         val uri = call.getUri()
         val body = call.getRequestBody()
-        return Pact.Interaction(
-            description = interactionOptions.description ?: "$uri",
-            providerStates = interactionOptions.providerStates?.map { Pact.Interaction.ProviderState(it) },
-            request = Pact.Interaction.Request(
-                method = call.getHttpMethod(),
-                path = uri.path,
-                query = uri.query,
-                headers = call.getHttpHeaders(),
-                body = body
-            ),
-            response = result.getResponse()
-        )
+        return interactionBuilder.build(request = Pact.Interaction.Request(
+            method = call.getHttpMethod(),
+            path = uri.path,
+            query = uri.query,
+            headers = call.getHttpHeaders(),
+            body = body
+        ),
+        response = result.getResponse())
     }
 
 

--- a/pact-jvm-mockk-spring/src/test/kotlin/io/github/ludorival/pactjvm/mockk/spring/contracts/ShoppingServiceContracts.kt
+++ b/pact-jvm-mockk-spring/src/test/kotlin/io/github/ludorival/pactjvm/mockk/spring/contracts/ShoppingServiceContracts.kt
@@ -25,8 +25,8 @@ fun RestTemplate.willCreateShoppingList(description: String? = null) = every {
         eq(ShoppingList::class.java)
     )
 } willRespondWith {
-    options {
-        this.description = description
+    description?.let {
+        this.description(it)
     }
     ResponseEntity.ok(
         EMPTY_SHOPPING_LIST
@@ -41,10 +41,8 @@ fun RestTemplate.willReturnAnErrorWhenCreateShoppingList() = every {
         eq(ShoppingList::class.java)
     )
 } willRespondWith {
-    options {
-        description = "should return a 400 Bad request"
-        providerStates = listOf("The request should return a 400 Bad request")
-    }
+    description("should return a 400 Bad request")
+    providerState("The request should return a 400 Bad request")
     anError(ResponseEntity.badRequest().body("The title contains unexpected character"))
 }
 
@@ -64,9 +62,7 @@ fun RestTemplate.willPatchShoppingItem() = every {
         eq(ShoppingList.Item::class.java)
     )
 } willRespondWith {
-    options {
-        description = "Patch a shopping item"
-    }
+    description("Patch a shopping item")
     val item = arg<ShoppingList.Item>(1)
     item
 }
@@ -79,9 +75,7 @@ fun RestTemplate.willListTwoShoppingLists() = every {
         any<ParameterizedTypeReference<List<ShoppingList>>>()
     )
 } willRespondWith {
-    options {
-        description = "list two shopping lists"
-    }
+    description("list two shopping lists")
     println(
         "I can have access to $args - $matcher - " +
             "$self - $nArgs -${firstArg<Any>()} - ${secondArg<Any>()} ${thirdArg<Any>()} ${lastArg<Any>()}"
@@ -99,9 +93,8 @@ fun RestTemplate.willDeleteShoppingItem() = every {
         match<URI> { it.path.contains("shopping-service") },
     )
 } willRespondWith {
-    options {
-        description = "delete shopping item"
-    }
+    description("delete shopping item")
+
 }
 
 fun RestTemplate.willUpdateShoppingList() = every {
@@ -110,9 +103,7 @@ fun RestTemplate.willUpdateShoppingList() = every {
         any()
     )
 } willRespondWith {
-    options {
-        description = "update shopping list"
-    }
+    description("update shopping list")
     println("I can have access to scope $scope")
 
 }

--- a/pact-jvm-mockk-spring/src/test/kotlin/io/github/ludorival/pactjvm/mockk/spring/contracts/UserServiceContracts.kt
+++ b/pact-jvm-mockk-spring/src/test/kotlin/io/github/ludorival/pactjvm/mockk/spring/contracts/UserServiceContracts.kt
@@ -1,5 +1,6 @@
 package io.github.ludorival.pactjvm.mockk.spring.contracts
 
+import io.github.ludorival.pactjvm.mockk.spring.USER_ID
 import io.github.ludorival.pactjvm.mockk.spring.USER_PROFILE
 import io.github.ludorival.pactjvm.mockk.spring.fakeapplication.infra.userservice.UserProfile
 import io.github.ludorival.pactjvm.mockk.willRespondWith
@@ -11,10 +12,8 @@ import org.springframework.web.client.RestTemplate
 fun RestTemplate.willReturnUserProfile() = every {
     getForEntity(match<String> { it.contains("user-service") }, UserProfile::class.java, *anyVararg())
 } willRespondWith {
-    options {
-        description = "get the user profile"
-        providerStates = listOf("The user has a preferred shopping list")
-    }
+    description("get the user profile")
+    providerState("The user has a preferred shopping list", mapOf("userId" to USER_ID))
     ResponseEntity.ok(
         USER_PROFILE
     )

--- a/pact-jvm-mockk-spring/src/test/resources/pacts-deterministic/shopping-list-shopping-service.json
+++ b/pact-jvm-mockk-spring/src/test/resources/pacts-deterministic/shopping-list-shopping-service.json
@@ -7,7 +7,7 @@
   },
   "interactions" : [ {
     "providerStates" : null,
-    "description" : "/shopping-service/user/123",
+    "description" : "POST /shopping-service/user/123? returns 200",
     "request" : {
       "method" : "POST",
       "path" : "/shopping-service/user/123",
@@ -107,7 +107,7 @@
     }
   }, {
     "providerStates" : null,
-    "description" : "/shopping-service/user/123/list/1",
+    "description" : "GET /shopping-service/user/123/list/1? returns 200",
     "request" : {
       "method" : "GET",
       "path" : "/shopping-service/user/123/list/1",
@@ -159,7 +159,8 @@
     }
   }, {
     "providerStates" : [ {
-      "name" : "The request should return a 400 Bad request"
+      "name" : "The request should return a 400 Bad request",
+      "params" : null
     } ],
     "description" : "should return a 400 Bad request",
     "request" : {

--- a/pact-jvm-mockk-spring/src/test/resources/pacts-deterministic/shopping-list-user-service.json
+++ b/pact-jvm-mockk-spring/src/test/resources/pacts-deterministic/shopping-list-user-service.json
@@ -7,7 +7,7 @@
   },
   "interactions" : [ {
     "providerStates" : null,
-    "description" : "http://localhost:1234/user-service/v1/user/123",
+    "description" : "PUT /user-service/v1/user/123? returns 200",
     "request" : {
       "method" : "PUT",
       "path" : "/user-service/v1/user/123",
@@ -31,7 +31,10 @@
     }
   }, {
     "providerStates" : [ {
-      "name" : "The user has a preferred shopping list"
+      "name" : "The user has a preferred shopping list",
+      "params" : {
+        "userId" : 123
+      }
     } ],
     "description" : "get the user profile",
     "request" : {

--- a/pact-jvm-mockk-spring/src/test/resources/pacts/shopping-list-shopping-service.json
+++ b/pact-jvm-mockk-spring/src/test/resources/pacts/shopping-list-shopping-service.json
@@ -7,7 +7,7 @@
   },
   "interactions" : [ {
     "providerStates" : null,
-    "description" : "/shopping-service/user/123",
+    "description" : "POST /shopping-service/user/123? returns 200",
     "request" : {
       "method" : "POST",
       "path" : "/shopping-service/user/123",
@@ -107,7 +107,7 @@
     }
   }, {
     "providerStates" : null,
-    "description" : "/shopping-service/user/123/list/1",
+    "description" : "GET /shopping-service/user/123/list/1? returns 200",
     "request" : {
       "method" : "GET",
       "path" : "/shopping-service/user/123/list/1",
@@ -159,7 +159,8 @@
     }
   }, {
     "providerStates" : [ {
-      "name" : "The request should return a 400 Bad request"
+      "name" : "The request should return a 400 Bad request",
+      "params" : null
     } ],
     "description" : "should return a 400 Bad request",
     "request" : {

--- a/pact-jvm-mockk-spring/src/test/resources/pacts/shopping-list-user-service.json
+++ b/pact-jvm-mockk-spring/src/test/resources/pacts/shopping-list-user-service.json
@@ -7,7 +7,7 @@
   },
   "interactions" : [ {
     "providerStates" : null,
-    "description" : "http://localhost:1234/user-service/v1/user/123",
+    "description" : "PUT /user-service/v1/user/123? returns 200",
     "request" : {
       "method" : "PUT",
       "path" : "/user-service/v1/user/123",
@@ -31,7 +31,10 @@
     }
   }, {
     "providerStates" : [ {
-      "name" : "The user has a preferred shopping list"
+      "name" : "The user has a preferred shopping list",
+      "params" : {
+        "userId" : 123
+      }
     } ],
     "description" : "get the user profile",
     "request" : {


### PR DESCRIPTION
## Overview

This pull request refactors the interaction DSL to enhance clarity and maintainability. The changes involve replacing the `InteractionOptions` with a new `InteractionBuilder` interface, providing a more flexible approach for defining interactions.

## Changes

- Introduced `InteractionBuilder` interface with methods `description` and `providerState`.
- Implemented `InteractionBuilderImpl` to handle interaction definitions.
- Removed `InteractionOptions` data class.
- Updated interaction definitions to use `description` and `providerState` methods for setting interaction details.
- Enhanced default interaction descriptions by incorporating request details.
- Updated relevant documentation to reflect changes in the interaction DSL.

## Impact

These changes streamline the process of defining interactions, improve the readability of the code, and produce more descriptive and clear pact files. This refactor will facilitate future enhancements and reduce potential errors in interaction setup.