### PR TITLE
Do not fail if the exception is not the expected one

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,6 +168,7 @@ project(":pact-jvm-mock") {
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("org.bitbucket.cowwoc.diff-match-patch:diff-match-patch:1.0")
         implementation(kotlin("stdlib-jdk8"))
+        implementation("org.slf4j:slf4j-api:2.0.16")
     }
 }
 project(":pact-jvm-mock-mockk") {

--- a/pact-jvm-mock-test/src/test/kotlin/io/github/ludorival/pactjvm/mock/test/MockkCoverageTest.kt
+++ b/pact-jvm-mock-test/src/test/kotlin/io/github/ludorival/pactjvm/mock/test/MockkCoverageTest.kt
@@ -268,6 +268,23 @@ class MockkCoverageTest {
         }
     }
 
+    @Test
+    fun `should not fail test when exception is not supported by adapter`() {
+        class UnsupportedCustomException(message: String) : RuntimeException(message)
+
+        given {
+            uponReceiving {
+                restTemplate.getForEntity(any<String>(), eq(String::class.java))
+            }.throws(UnsupportedCustomException("Custom error"))
+        } `when` {
+            assertThrows<UnsupportedCustomException> {
+                restTemplate.getForEntity("$TEST_API_1_URL/unsupported-error", String::class.java)
+            }
+        } then {
+            assertNull(getCurrentPact(API_1))
+        }
+    }
+
     companion object {
         val API_1 = "service1"
         val TEST_API_1_URL = "http://localhost:8080/$API_1/api/v1"

--- a/pact-jvm-mock/src/main/kotlin/io/github/ludorival/pactjvm/mock/Utils.kt
+++ b/pact-jvm-mock/src/main/kotlin/io/github/ludorival/pactjvm/mock/Utils.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializerProvider
+import org.slf4j.LoggerFactory
 
  fun <T> serializerWith( supplier: (JsonGenerator) -> Unit) = object : JsonSerializer<T>() {
     override fun serialize(value: T, gen: JsonGenerator, serializers: SerializerProvider?) {
@@ -28,3 +29,5 @@ fun clearPact(providerName: String) {
 }
 
 typealias InteractionHandler<R> = (Pact.Interaction) -> R
+
+internal val LOGGER = LoggerFactory.getLogger(PactMock::class.java)


### PR DESCRIPTION
- Fixes #252
- Added SLF4J API dependency to `build.gradle.kts` for improved logging capabilities.
- Integrated detailed debug logging in `PactMock` to track pact clearing, creation, and interaction addition processes.
- Updated `PactToWrite` to log warnings when interaction descriptions change and when pacts are successfully written.
- Introduced a new test case to ensure that exceptions not supported by the adapter do not cause test failures.

These changes improve observability and error handling in the pact-jvm-mock library.